### PR TITLE
Fix scrapbook widget cors error

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -1,5 +1,17 @@
 const withMDX = require('@next/mdx')({ extension: /\.mdx?$/ })
+
 module.exports = withMDX({
-  pageExtensions: ['js', 'jsx', 'mdx'],
-  assetPrefix: process.env.NODE_ENV === 'production' ? '/summer' : ''
+  extension: /\.mdx?$/,
+  options: {
+    pageExtensions: ['js', 'jsx', 'mdx'],
+    assetPrefix: process.env.NODE_ENV === 'production' ? '/summer' : ''
+  },
+  async headers() {
+    return [
+      {
+        source: '/scrapbookwidget.js',
+        headers: [{ key: 'Access-Control-Allow-Origin', value: '*' }]
+      }
+    ]
+  }
 })


### PR DESCRIPTION
`scrapbook.hackclub.com/scrapbookwidget.js` is now working, but there are [some sites](https://riley.is-a.dev) that still rely on `summer.hackclub.com/scrapbookwidget.js`. This PR attempts to fix the CORS error that's coming from summer.hackclub.com.


 